### PR TITLE
Use digital filter correction factor in butterworth.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include AUTHORS
 include README.rst
 include UNLICENSE.txt
 include dtk/test/data/*

--- a/dtk/process.py
+++ b/dtk/process.py
@@ -448,12 +448,12 @@ def freq_spectrum(data, sampleRate):
     f = fftfreq(n, d=time)
     #f = sampleRate/2.*linspace(0, 1, n)
     #print 'f =', f, f.shape, type(f)
-    frequency = f[1:n / 2]
+    frequency = f[1:n//2]
     try:
-        amplitude = 2 * abs(Y[:, 1:n / 2]).T # multiply by 2 because we take half the vector
+        amplitude = 2 * abs(Y[:, 1:n//2]).T # multiply by 2 because we take half the vector
         #power = abs(Y[:, 1:n/2])**2
     except:
-        amplitude = 2 * abs(Y[1:n / 2])
+        amplitude = 2 * abs(Y[1:n//2])
         #power = abs(Y[1:n/2])**2
     return frequency, amplitude
 
@@ -475,7 +475,7 @@ def butterworth(data, cutoff, samplerate, order=2, axis=-1, btype='lowpass',
         The order of the Butterworth filter.
     axis : int
         The axis to filter along.
-    btype : {'lowpass'|'highpass'|'bandpass'|'bandstop'}
+    btype : {'lowpass'|'highpass'}
         The type of filter. Default is 'lowpass'.
     kwargs
         Any extra arguments to get passed to scipy.signal.sosfiltfilt.
@@ -513,8 +513,15 @@ def butterworth(data, cutoff, samplerate, order=2, axis=-1, btype='lowpass',
 
     correction_factor = (np.sqrt(2.0) - 1.0)**(1.0/(2.0*order))
     cutoff_radps = np.tan(np.pi*cutoff/samplerate)
-    cutoff_corrected_hz = samplerate/np.pi*np.arctan(
-        cutoff_radps/correction_factor)
+    if btype == 'highpass':
+        cutoff_corrected_hz = samplerate/np.pi*np.arctan(
+            cutoff_radps*correction_factor)
+    elif btype == 'lowpass':
+        # TODO : Not sure if this is correct for bandpass and bandstop
+        cutoff_corrected_hz = samplerate/np.pi*np.arctan(
+            cutoff_radps/correction_factor)
+    else:
+        raise ValueError("btype='{}' not supported.".format(btype))
 
     # Wn is the ratio of the corrected cutoff frequency to the Nyquist
     # frequency.

--- a/dtk/process.py
+++ b/dtk/process.py
@@ -414,47 +414,46 @@ def freq_spectrum(data, sampleRate):
 
     Parameters
     ----------
-    data : ndarray, shape (m,) or shape(n,m)
-        The array of time signals where n is the number of variables and m is
-        the number of time steps.
+    data : array_like, shape (m, ) or shape(n, m)
+        The array of time signals where ``n`` is the number of variables and
+        ``m`` is the number of time steps.
     sampleRate : int
-        The signal sampling rate in hertz.
+        The signal sampling rate in Hertz.
 
     Returns
     -------
     frequency : ndarray, shape (p,)
-        The frequencies where p is a power of 2 close to m.
-    amplitude : ndarray, shape (p,n)
-        The amplitude at each frequency.
+        Frequencies where ``p`` is a power of 2 close to ``m``, in Hertz.
+    amplitude : ndarray, shape (p, n)
+        Amplitude at each frequency.
 
     """
     def nextpow2(i):
-        '''
-        Return the next power of 2 for the given number.
-
-        '''
+        '''Return the next power of 2 for the given number.'''
         n = 2
-        while n < i: n *= 2
+        while n < i:
+            n *= 2
         return n
 
-    time = 1. / sampleRate # sample time
+    time = 1./sampleRate  # sample time
     try:
-        L = data.shape[1] # length of data if (n, m)
-    except:
-        L = data.shape[0] # length of data if (n,)
+        L = data.shape[1]  # length of data if (n, m)
+    except IndexError:
+        L = data.shape[0]  # length of data if (n,)
     # calculate the closest power of 2 for the length of the data
     n = nextpow2(L)
-    Y = fft(data, n) / L # divide by L for scaling
+    Y = fft(data, n)/L  # divide by L for scaling
     f = fftfreq(n, d=time)
-    #f = sampleRate/2.*linspace(0, 1, n)
-    #print 'f =', f, f.shape, type(f)
+    # f = sampleRate/2.*linspace(0, 1, n)
+    # print 'f =', f, f.shape, type(f)
     frequency = f[1:n//2]
     try:
-        amplitude = 2 * abs(Y[:, 1:n//2]).T # multiply by 2 because we take half the vector
-        #power = abs(Y[:, 1:n/2])**2
-    except:
-        amplitude = 2 * abs(Y[1:n//2])
-        #power = abs(Y[1:n/2])**2
+        # multiply by 2 because we take half the vector
+        amplitude = 2*abs(Y[:, 1:n//2]).T
+        # power = abs(Y[:, 1:n/2])**2
+    except IndexError:
+        amplitude = 2*abs(Y[1:n//2])
+        # power = abs(Y[1:n/2])**2
     return frequency, amplitude
 
 
@@ -517,7 +516,6 @@ def butterworth(data, cutoff, samplerate, order=2, axis=-1, btype='lowpass',
         cutoff_corrected_hz = samplerate/np.pi*np.arctan(
             cutoff_radps*correction_factor)
     elif btype == 'lowpass':
-        # TODO : Not sure if this is correct for bandpass and bandstop
         cutoff_corrected_hz = samplerate/np.pi*np.arctan(
             cutoff_radps/correction_factor)
     else:

--- a/dtk/process.py
+++ b/dtk/process.py
@@ -507,9 +507,6 @@ def butterworth(data, cutoff, samplerate, order=2, axis=-1, btype='lowpass',
     # fs : sample rate in Hz
     # wc : cutoff frequency in rad/s
 
-    # TODO : Figure out if the correction is the same for low and high pass
-    # filters.
-
     correction_factor = (np.sqrt(2.0) - 1.0)**(1.0/(2.0*order))
     cutoff_radps = np.tan(np.pi*cutoff/samplerate)
     if btype == 'highpass':

--- a/dtk/test/test_process.py
+++ b/dtk/test/test_process.py
@@ -167,10 +167,6 @@ def test_derivative():
 
 def test_butterworth():
 
-    nine = LooseVersion('0.9.0')
-    ten = LooseVersion('0.10.0')
-    current = LooseVersion(scipy_version)
-
     # setup
     time = np.linspace(0.0, 1.0, 2001)
     sample_rate = 1.0 / np.diff(time).mean()
@@ -182,12 +178,7 @@ def test_butterworth():
     filtered = process.butterworth(low_freq + high_freq, 125.0, sample_rate,
                                    order=8, axis=0, padlen=150)
 
-    if current >= nine and current < ten:
-        # SciPy 0.9.0 can't handle the end points.
-        testing.assert_allclose(filtered[50:-50], low_freq[50:-50],
-                                rtol=0.01, atol=0.01)
-    else:
-        testing.assert_allclose(filtered, low_freq, rtol=3e-5, atol=3e-5)
+    testing.assert_allclose(filtered, low_freq, rtol=3e-5, atol=3e-5)
 
     # shape(n,2)
     data = np.vstack((low_freq + high_freq, low_freq + high_freq)).T
@@ -197,12 +188,7 @@ def test_butterworth():
 
     expected = np.vstack((low_freq, low_freq)).T
 
-    if current >= nine and current < ten:
-        # SciPy 0.9.0 can't handle the end points.
-        testing.assert_allclose(filtered[50:-50], expected[50:-50],
-                                rtol=0.01, atol=0.01)
-    else:
-        testing.assert_allclose(filtered, expected, rtol=3e-5, atol=3e-5)
+    testing.assert_allclose(filtered, expected, rtol=3e-5, atol=3e-5)
 
     # shape(2,n)
     data = np.vstack((low_freq + high_freq, low_freq + high_freq))
@@ -212,12 +198,7 @@ def test_butterworth():
 
     expected = np.vstack((low_freq, low_freq))
 
-    if current >= nine and current < ten:
-        # SciPy 0.9.0 can't handle the end points.
-        testing.assert_allclose(filtered[:, 50:-50], expected[:, 50:-50],
-                                rtol=0.01, atol=0.01)
-    else:
-        testing.assert_allclose(filtered, expected, rtol=1e-5, atol=1e-3)
+    testing.assert_allclose(filtered, expected, rtol=1e-5, atol=1e-3)
 
 
 def test_coefficient_of_determination():


### PR DESCRIPTION
Fixes #37
    
Before this commit the butterworth() function applied the correction
factor based on the analog filter math, but butter() creates a digital
filter by default and the correction factor then must be calculated
using the cutoff frequency relationship wc = tan(pi*fc/fs) which
converts the cutoff frequency in Hertz to cutoff frequency in rad/s
accounting for the digital sampling rate.
