### PR TITLE
Normalization of spectral analysis

### DIFF
--- a/dtk/process.py
+++ b/dtk/process.py
@@ -662,13 +662,13 @@ def power_spectrum(data, sample_rate, remove_dc_component=False):
 
     Notes
     -----
-    - power_spectrum() performs zero-padding. Parseval's
+    - ``power_spectrum()`` performs zero-padding. Parseval's
       theorem is satisfied for the padded input signal. Provide input signals
       with 2^p samples to prevent zero-padding.
     - The power contributions of positive and negative frequencies are
       combined in the positive half spectrum so that the results satisfy
-      Parseval's theoreom on the interval [0, f_N].
-    - If the dc component is removed with remove_dc_component=True, the results
+      Parseval's theoreom on the interval ``[0, f_N]``. This calculates total power.
+    - If the dc component is removed with ``remove_dc_component=True``, the results
       do not satisfy Parseval's theorem.
 
     Parameters
@@ -680,8 +680,8 @@ def power_spectrum(data, sample_rate, remove_dc_component=False):
         The signal sampling rate in Hertz.
     remove_dc_component : bool, optional
         If True, the DC component (f = 0) is not included in the returned
-        spectrum ]0,f_N[. If False the returned spectrum covers
-        [0, f_N[. The default is True.
+        spectrum ``]0,f_N[``. If False the returned spectrum covers
+        ``[0, f_N[``. The default is True.
 
 
     Returns
@@ -746,7 +746,7 @@ def power_spectrum(data, sample_rate, remove_dc_component=False):
     # call freq_spectrum with orthonormal normalization (i.e. 1/sqrt(N)) to
     # ensure that Parseval's theorem is satisfied.
     frequency, amplitude = freq_spectrum(
-        data, sample_rate, norm="ortho",
+        data, sample_rate, norm="forward",
         remove_dc_component=remove_dc_component)
 
     # Power is the square of the amplitude.
@@ -776,7 +776,7 @@ def cumulative_power_spectrum(data, sample_rate, relative=True,
       samples to prevent zero-padding.
     - The power contributions of positive and negative frequencies are
       combined in the positive half spectrum so that the results satisfy
-      Parseval's theoreom on the interval ``[0, f_N]``.
+      Parseval's theoreom on the interval ``[0, f_N]``. This calculates total power.
     - If the dc component is removed with ``remove_dc_component=True``, the
       results do not satisfy Parseval's theorem.
 

--- a/dtk/process.py
+++ b/dtk/process.py
@@ -633,7 +633,7 @@ def freq_spectrum(data, sampleRate, norm="forward", remove_dc_component=True):
     # calculate the closest power of 2 for the length of the data
     n = nextpow2(L)
 
-    Y = fft(data, n, norm="forward")
+    Y = fft(data, n, norm=norm)
     f = fftfreq(n, d=time)
     # f = sampleRate/2.*linspace(0, 1, n)
     # print 'f =', f, f.shape, type(f)


### PR DESCRIPTION
Changes:
- Pass `norm` argument to `numpy.fft.fft()` in `process.freq_spectrum()` (fixes #54) 
- Correct normalization for power spectra from `ortho` to `forward` (error emerged after fixing the above). The magnitudes of the power spectra continue to satisfy Parseval's Theorem.  